### PR TITLE
Pin ogre to 1.10.*

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
     sha256: 26e4f26ca5799f445bef9ad5ef307da4b180bebe593a1c925246598eb61b8521
 
 build:
-  number: 2
+  number: 3
   
 outputs:
   - name: {{ cxx_name }}
@@ -42,7 +42,7 @@ outputs:
         - libprotobuf
         - tbb-devel
         - libopencv
-        - ogre
+        - ogre 1.10.*
       run:
         - __osx >={{ MACOSX_DEPLOYMENT_TARGET|default("10.9") }}  # [osx and x86_64]
 


### PR DESCRIPTION
`libgazebo-yarp-plugins` depends transitively on ogre. However, it needs to depend on ogre 1.10.* as ogre 1.12.* build of Gazebo do not work and have been removed in https://github.com/conda-forge/gazebo-feedstock/pull/164 .

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
